### PR TITLE
Add upgrade path for recent changes

### DIFF
--- a/2.x-activity-module/mod/aspirelists/db/upgrade.php
+++ b/2.x-activity-module/mod/aspirelists/db/upgrade.php
@@ -107,4 +107,8 @@ function xmldb_aspirelists_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2014042301, 'aspirelists');
     }
 
+    if ($oldversion < 2015092900){
+        upgrade_mod_savepoint(true, 2015092900, 'aspirelists');
+    }
+
 }

--- a/2.x-activity-module/mod/aspirelists/version.php
+++ b/2.x-activity-module/mod/aspirelists/version.php
@@ -1,7 +1,7 @@
 <?php
 defined('MOODLE_INTERNAL') || die();
 
-$module->version   = 2015092500;
+$module->version   = 2015092900;
 $module->requires  = 2012062507; // See http://docs.moodle.org/dev/Moodle_Versions
 $module->cron      = 0;
 $module->component = 'mod_aspirelists';


### PR DESCRIPTION
Forgot to add the upgrade path following the recent version bump, so re-bumping the version and adding the path.