### PR TITLE
added plugin var instead of module var

### DIFF
--- a/2.x-activity-module/mod/aspirelists/version.php
+++ b/2.x-activity-module/mod/aspirelists/version.php
@@ -1,9 +1,24 @@
 <?php
 defined('MOODLE_INTERNAL') || die();
 
-$module->version   = 2015112400;
-$module->requires  = 2012062507; // See http://docs.moodle.org/dev/Moodle_Versions
-$module->cron      = 0;
-$module->component = 'mod_aspirelists';
-$module->maturity  = MATURITY_ALPHA;
-$module->release   = '.0001';
+if (!isset($plugin)) {
+    // Avoid warning message in M2.5 and below.
+    $plugin = new stdClass();
+}
+
+$plugin->version   = 2015112400;
+$plugin->requires  = 2012062507; // See http://docs.moodle.org/dev/Moodle_Versions
+$plugin->cron      = 0;
+$plugin->component = 'mod_aspirelists';
+$plugin->maturity  = MATURITY_ALPHA;
+$plugin->release   = '.0001';
+
+if ($CFG->branch < 26) {
+    // Used by M2.5 and below.
+    $module->version = $plugin->version;
+    $module->cron = $plugin->cron;
+    $module->maturity = $plugin->maturity;
+    $module->release = $plugin->release;
+    $module->requires = $plugin->requires;
+    $module->component = $plugin->component;
+}


### PR DESCRIPTION
Moodle 3.0 no longer accepts the $module variable in the version file, it should be $plugin. I've left a version check in place so that older Moodle versions are still supported.