### PR TITLE
Fix incorrect version number

### DIFF
--- a/2.4/blocks/aspirelists/version.php
+++ b/2.4/blocks/aspirelists/version.php
@@ -4,6 +4,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 20180301757;  // YYYYMMDDHH (year, month, day, 24-hr time)
+$plugin->version = 201803081830;  // YYYYMMDDHHMM (year, month, day, 24-hr time)
 $plugin->requires = 2012120300; // YYYYMMDDHH (This is the release version for Moodle 2.4)
 $plugin->component = 'block_aspirelists';


### PR DESCRIPTION
Missing a digit in the previous version number.  This was breaking updates as it was a lower integer than any previous version number.