### PR TITLE
Ensure latest moodle includes correct context data

### DIFF
--- a/2.4/blocks/aspirelists/version.php
+++ b/2.4/blocks/aspirelists/version.php
@@ -4,6 +4,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 201803081830;  // YYYYMMDDHHMM (year, month, day, 24-hr time)
+$plugin->version = 201805291000;  // YYYYMMDDHHMM (year, month, day, 24-hr time)
 $plugin->requires = 2012120300; // YYYYMMDDHH (This is the release version for Moodle 2.4)
 $plugin->component = 'block_aspirelists';

--- a/2.x-activity-module/mod/aspirelists/db/upgrade.php
+++ b/2.x-activity-module/mod/aspirelists/db/upgrade.php
@@ -131,4 +131,8 @@ function xmldb_aspirelists_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2017070400, 'aspirelists');
     }
 
+    if ($oldversion < 201805291000){
+        upgrade_mod_savepoint(true, 201805291000, 'aspirelists');
+    }
+
 }

--- a/2.x-activity-module/mod/aspirelists/launch.php
+++ b/2.x-activity-module/mod/aspirelists/launch.php
@@ -18,6 +18,11 @@ $list = $DB->get_record('aspirelists', array('id' => $cm->instance), '*', MUST_E
 $course = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);
 $context = context_module::instance($cm->id);
 
+if($CFG->version >= 2017111300) {
+    $PAGE->set_cm($cm, $course); // set up global $COURSE
+}
+
+// Log the launch
 if($CFG->version < 2014051200) {
     add_to_log($course->id, "aspirelists", "launch", "launch.php?id=$cm->id", "$list->id");
 } else {
@@ -32,6 +37,7 @@ if($CFG->version < 2014051200) {
     $event->trigger();
 }
 
+// Perform the launch
 $list->cmid = $cm->id;
 aspirelists_add_lti_properties($list);
 if($CFG->version >= 2015111600) {


### PR DESCRIPTION
A change in moodle 3.4 means our plugin is only passing through the "root" module details for ``context_label`` and ``context_title``, rather than the currently selected module.  

This is okay in most circumstances as the ``custom_knowledge_grouping`` parameter works to pass through the found module code and time periods separately.  However there are two scenarios where this causes a direct problem:
  - Being able to view the module code data used (for debugging regex purposes)
  - If trying to match against the list title, as this only takes place on the tarl-server-side.