### PR TITLE
Update the moodle / php versions we are testing to supported versions only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,41 +6,68 @@ cache:
   directories:
     - $HOME/.composer/cache
 
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-
-env:
-  - MOODLE_BRANCH=MOODLE_26_STABLE DB=mysqli
-  - MOODLE_BRANCH=MOODLE_27_STABLE DB=mysqli
-  - MOODLE_BRANCH=MOODLE_28_STABLE DB=mysqli
-  - MOODLE_BRANCH=MOODLE_29_STABLE DB=mysqli
-  - MOODLE_BRANCH=MOODLE_30_STABLE DB=mysqli
-  - MOODLE_BRANCH=MOODLE_31_STABLE DB=mysqli
-  - MOODLE_BRANCH=MOODLE_26_STABLE DB=pgsql
-  - MOODLE_BRANCH=MOODLE_27_STABLE DB=pgsql
-  - MOODLE_BRANCH=MOODLE_28_STABLE DB=pgsql
-  - MOODLE_BRANCH=MOODLE_29_STABLE DB=pgsql
-  - MOODLE_BRANCH=MOODLE_30_STABLE DB=pgsql
-  - MOODLE_BRANCH=MOODLE_31_STABLE DB=pgsql
-
 matrix:
   fast_finish: true
   include:
-    - php: 7.0
-      env: MOODLE_BRANCH=MOODLE_30_STABLE DB=pgsql
-    - php: 7.0
-      env: MOODLE_BRANCH=MOODLE_30_STABLE DB=mysqli
-    - php: 7.0
+    - php: 5.6
       env: MOODLE_BRANCH=MOODLE_31_STABLE DB=pgsql
-    - php: 7.0
+    - php: 5.6
       env: MOODLE_BRANCH=MOODLE_31_STABLE DB=mysqli
+    - php: 5.6
+      env: MOODLE_BRANCH=MOODLE_33_STABLE DB=pgsql
+      addons:
+        postgresql: "9.3"
+    - php: 5.6
+      env: MOODLE_BRANCH=MOODLE_33_STABLE DB=mysqli
+
+    - php: 7.1
+      env: MOODLE_BRANCH=MOODLE_33_STABLE DB=pgsql
+      addons:
+        postgresql: "9.3"
+    - php: 7.1
+      env: MOODLE_BRANCH=MOODLE_33_STABLE DB=mysqli
+    - php: 7.1
+      env: MOODLE_BRANCH=MOODLE_34_STABLE DB=pgsql
+      addons:
+        postgresql: "9.3"
+    - php: 7.1
+      env: MOODLE_BRANCH=MOODLE_34_STABLE DB=mysqli
+    - php: 7.1
+      env: MOODLE_BRANCH=MOODLE_35_STABLE DB=pgsql
+      addons:
+        postgresql: "9.3"
+    - php: 7.1
+      env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
+    - php: 7.1
+      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql
+      addons:
+        postgresql: "9.4"
+    - php: 7.1
+      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=mysqli
+
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_34_STABLE DB=pgsql
+      addons:
+        postgresql: "9.3"
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_34_STABLE DB=mysqli
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_35_STABLE DB=pgsql
+      addons:
+        postgresql: "9.3"
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_35_STABLE DB=mysqli
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql
+      addons:
+        postgresql: "9.4"
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=mysqli
 
 before_install:
   - phpenv config-rm xdebug.ini
   - composer selfupdate
-  - composer create-project -n --no-dev --prefer-dist moodlerooms/moodle-plugin-ci ci ^1
+  - composer create-project -n --no-dev --prefer-dist blackboard-open-source/moodle-plugin-ci ci ^1
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
 
 install:


### PR DESCRIPTION
Updating to only test against combinations of moodle and php which are currently still supported.  One exception is also testing against php 5.6, as it's not unreasonable to presume that there may still be 5.x servers out there serving moodle.  However we should look to drop php 5.x support entirely as soon as we can.