### PR TITLE
Implement Privacy API

### DIFF
--- a/moodle-activity-module-lti-wrapper/mod/aspirelists/lang/en/aspirelists.php
+++ b/moodle-activity-module-lti-wrapper/mod/aspirelists/lang/en/aspirelists.php
@@ -83,3 +83,12 @@ $string['accordion_open'] = '&#9660;';
 $string['config_defaultInlineListHeight'] = 'Default height of an embedded list';
 $string['config_defaultInlineListHeight_desc'] = 'The default height of an inline embedded list in the course view';
 $string['config_defaultInlineListHeight_default'] = '400px' ;
+
+$string['privacy:metadata:reason'] = 'The Aspire Lists LTI Wrapper does not store any user data in Moodle, but some user data is passed via LTI.';
+$string['privacy:metadata:lti_client'] = 'In order to integrate with a remote Talis Aspire LTI Tool Provider, user data needs to be exchanged with Talis Aspire.';
+$string['privacy:metadata:lti_client:userid'] = 'The userid is sent from Moodle to allow you to access your data in Talis Aspire.';
+$string['privacy:metadata:lti_client:role'] = 'The role is sent from Moodle to allow you to have the right experience in Talis Aspire.';
+$string['privacy:metadata:lti_client:courseid'] = 'The courseid is sent from Moodle to allow you to find the right list in Talis Aspire.';
+$string['privacy:metadata:lti_client:courseidnumber'] = 'The courseidnumber is sent from Moodle to allow you to find the right list in Talis Aspire.';
+$string['privacy:metadata:lti_client:courseshortname'] = 'The courseshortname is sent from Moodle to allow you to find the right list in Talis Aspire.';
+$string['privacy:metadata:lti_client:coursefullname'] = 'The coursefullname is sent from Moodle to allow you to find the right list in Talis Aspire.';

--- a/moodle-activity-module-lti-wrapper/mod/aspirelists/privacy/provider.php
+++ b/moodle-activity-module-lti-wrapper/mod/aspirelists/privacy/provider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace mod_aspirelists\privacy;
+use core_privacy\local\metadata\collection;
+
+// This plugin does not store any personal user data in the database, but does cause LTI connections to be made.
+class provider implements \core_privacy\local\metadata\provider {
+
+    /**
+     * Get the language string to show as a reason.
+     * @return string
+     */
+    public static function get_reason() : string {
+        return 'privacy:metadata:reason';
+    }
+
+    public static function get_metadata(collection $collection) : collection {
+
+        $collection->add_external_location_link('lti_client', [
+            'userid' => 'privacy:metadata:lti_client:userid',
+            'role' => 'privacy:metadata:lti_client:role',
+            'courseid' => 'privacy:metadata:courseid',
+            'courseidnumber' => 'privacy:metadata:courseidnumber',
+            'courseshortname' => 'privacy:metadata:courseshortname',
+            'coursefullname' => 'privacy:metadata:coursefullname',
+        ], 'privacy:metadata:lti_client');
+
+        return $collection;
+    }
+}


### PR DESCRIPTION
Implements the Moodle Privacy API.

* We don't store any user data in the db.
* We do cause an LTI connection to be made using `mod_lti` which will send us some user data.