### PR TITLE
Deprecate iFrame Maximise

### DIFF
--- a/moodle-activity-module-lti-wrapper/mod/aspirelists/db/upgrade.php
+++ b/moodle-activity-module-lti-wrapper/mod/aspirelists/db/upgrade.php
@@ -139,4 +139,8 @@ function xmldb_aspirelists_upgrade($oldversion) {
     if ($oldversion < 2019101500){
         upgrade_mod_savepoint(true, 2019101500, 'aspirelists');
     }
+
+    if ($oldversion < 2020010700){
+        upgrade_mod_savepoint(true, 2020010700, 'aspirelists');
+    }
 }

--- a/moodle-activity-module-lti-wrapper/mod/aspirelists/lang/en/aspirelists.php
+++ b/moodle-activity-module-lti-wrapper/mod/aspirelists/lang/en/aspirelists.php
@@ -83,6 +83,8 @@ $string['accordion_open'] = '&#9660;';
 $string['config_defaultInlineListHeight'] = 'Default height of an embedded list';
 $string['config_defaultInlineListHeight_desc'] = 'The default height of an inline embedded list in the course view';
 $string['config_defaultInlineListHeight_default'] = '400px' ;
+$string['config_maximiseFrameSize_visiblename'] = 'Maximise Frame Size' ;
+$string['config_maximiseFrameSize_description'] = 'Deprecated: This was required under older versions of moodle, but is now "off" by default as it causes display issues at higher text size or page zoom levels.  If switched on it will attempt to maximise the iframe using javascript.' ;
 
 $string['privacy:metadata:reason'] = 'The Aspire Lists LTI Wrapper does not store any user data in Moodle, but some user data is passed via LTI.';
 $string['privacy:metadata:lti_client'] = 'In order to integrate with a remote Talis Aspire LTI Tool Provider, user data needs to be exchanged with Talis Aspire. No user data is stored in Moodle by this plugin';

--- a/moodle-activity-module-lti-wrapper/mod/aspirelists/settings.php
+++ b/moodle-activity-module-lti-wrapper/mod/aspirelists/settings.php
@@ -23,3 +23,12 @@
     $settings->add(new \admin_setting_configtext('mod_aspirelists/timePeriodMapping',\get_string('config_timePeriodMapping', 'mod_aspirelists'), \get_string('config_timePeriodMapping_desc', 'mod_aspirelists'), \get_string('config_timePeriodMapping_ex', 'mod_aspirelists') ));
 
     $settings->add(new \admin_setting_configtext('mod_aspirelists/defaultInlineListHeight',\get_string('config_defaultInlineListHeight', 'mod_aspirelists'), \get_string('config_defaultInlineListHeight_desc', 'mod_aspirelists'), \get_string('config_defaultInlineListHeight_default', 'mod_aspirelists') ));
+
+    $settings->add(new \admin_setting_configcheckbox(
+        'mod_aspirelists/maximiseFrameSize',
+        \get_string('config_maximiseFrameSize_visiblename', 'mod_aspirelists'),
+        \get_string('config_maximiseFrameSize_description', 'mod_aspirelists'),
+        '0', // Default value
+        '1', // Checked value
+        '0'  // Unchecked value
+    ));

--- a/moodle-activity-module-lti-wrapper/mod/aspirelists/version.php
+++ b/moodle-activity-module-lti-wrapper/mod/aspirelists/version.php
@@ -7,7 +7,7 @@ if (!isset($plugin)) {
     $plugin = new stdClass();
 }
 
-$plugin->version   = 2019101500; // Version for this plugin - based on the date and then an increment number
+$plugin->version   = 2020010700; // Version for this plugin - based on the date and then an increment number
 $plugin->requires  = 2018051700; // Lowest Moodle version required. See http://docs.moodle.org/dev/Moodle_Versions
 $plugin->cron      = 0;
 $plugin->component = 'mod_aspirelists';

--- a/moodle-activity-module-lti-wrapper/mod/aspirelists/view.php
+++ b/moodle-activity-module-lti-wrapper/mod/aspirelists/view.php
@@ -126,7 +126,7 @@ if ( $launchcontainer == LTI_LAUNCH_CONTAINER_WINDOW ) {
     // Request the launch content with an iframe tag instead of the standard moodle LTI object tag
     echo '<iframe id="contentframe" height="600px" width="100%" type="text/html" src="launch.php?id='.$cm->id.'" frameborder="0"></iframe>';
 
-    //Output script to make the object tag be as large as possible
+    // Prep script to make the object tag be as large as possible
     $resize = '
         <script type="text/javascript">
         //<![CDATA[
@@ -160,7 +160,11 @@ if ( $launchcontainer == LTI_LAUNCH_CONTAINER_WINDOW ) {
         </script>
 ';
 
-    echo $resize;
+    $pluginSettings = \get_config('mod_aspirelists');
+    // Apply resize script if plugin setting is checked
+    if(!empty($pluginSettings->maximiseFrameSize)) {
+        echo $resize;
+    }
 }
 
 // Finish the page


### PR DESCRIPTION
Previously the plugin had to use javascript to ensure the iframe scaled properly in older versions of moodle.  This doesn't appear to be the case anymore and is causing issues when the text size is scaled high (eg. 200%), potentially causing accessibility problems.

Now this has been deprecated and removed by default, however a checkbox option to switch it back on has been added to the plugin settings.